### PR TITLE
Add allow censored value to be given and calculate overall c-index

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY server_config/nginx /etc/nginx/sites-available/default
 COPY server_config/docker-entrypoint.sh /entrypoint.sh
 
 RUN conda config --append channels conda-forge
-RUN conda install -c sebp scikit-survival
+RUN conda install -c sebp scikit-survival==0.16.0
 COPY ./requirements.txt /app/requirements.txt
 RUN pip3 install -r /app/requirements.txt
 COPY . /app

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ fc_survival_evaluation:
     sep: ","
     label_survival_time: "tte"
     label_event: "event"
-    event_truth_value: True  # optional, default=True; value of an entry in the event column when a event occurred
+    event_value: 'True'  # optional, default='True'; value of an entry in the event column when an event occurred
+    event_censored_value: 'False'  # optional, default='False'; value of an entry in the event column when censored
     label_predicted_time: "predicted_tte"
   parameters:
     objective: regression  # can be regression or ranking

--- a/app/logic.py
+++ b/app/logic.py
@@ -119,8 +119,8 @@ class AppLogic:
             self.actual = dict.fromkeys([f.path for f in os.scandir(f'{self.INPUT_DIR}/{self.dir}') if f.is_dir()])
             self.predicted = dict.fromkeys(self.actual)
         else:
-            self.actual[self.INPUT_DIR] = None
-            self.predicted[self.INPUT_DIR] = None
+            self.actual[self.INPUT_DIR] = {}
+            self.predicted[self.INPUT_DIR] = {}
 
         os.makedirs(self.OUTPUT_DIR, exist_ok=True)
         for split in self.actual.keys():

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ psutil
 requests
 kaleido
 pandas
-nptyping
+nptyping==1.4.4
 scipy
 sklearn

--- a/sample_data/veteran/client_0/config.yml
+++ b/sample_data/veteran/client_0/config.yml
@@ -8,7 +8,8 @@ fc_survival_evaluation:
     sep: ","
     label_survival_time: "time"
     label_event: "status"
-    event_truth_value: 0  # optional, default=True; value of an entry in the event column when a event occurred
+    event_value: '0'  # optional, default='True'; value of an entry in the event column when an event occurred
+    event_censored_value: '1'  # optional, default='False'; value of an entry in the event column when censored
     label_predicted_time: "predicted_tte"
   parameters:
     objective: regression

--- a/sample_data/veteran/client_1/config.yml
+++ b/sample_data/veteran/client_1/config.yml
@@ -8,7 +8,8 @@ fc_survival_evaluation:
     sep: ","
     label_survival_time: "time"
     label_event: "status"
-    event_truth_value: 0  # optional, default=True; value of an entry in the event column when a event occurred
+    event_value: '0'  # optional, default='True'; value of an entry in the event column when an event occurred
+    event_censored_value: '1'  # optional, default='False'; value of an entry in the event column when censored
     label_predicted_time: "predicted_tte"
   parameters:
     objective: regression

--- a/sample_data/veteran/client_2/config.yml
+++ b/sample_data/veteran/client_2/config.yml
@@ -8,7 +8,8 @@ fc_survival_evaluation:
     sep: ","
     label_survival_time: "time"
     label_event: "status"
-    event_truth_value: 0  # optional, default=True; value of an entry in the event column when a event occurred
+    event_value: '0'  # optional, default='True'; value of an entry in the event column when an event occurred
+    event_censored_value: '1'  # optional, default='False'; value of an entry in the event column when censored
     label_predicted_time: "predicted_tte"
   parameters:
     objective: regression


### PR DESCRIPTION
Hi @julianspaeth,

this PR encompasses the changes we talked about:
- As in the survival SVM app the user can give a censored value now; rows where the status does not match the event value or censored value are dropped
- An overall c-index is calculated when splits where used

I've also pinned the dependencies to the versions used in the survival SVM app.